### PR TITLE
Move stdlib=libc++ to OSX only section

### DIFF
--- a/LibKeyFinder.pro
+++ b/LibKeyFinder.pro
@@ -30,8 +30,7 @@ TEMPLATE = lib
 VERSION = 2.1.0
 
 CONFIG += c++11
-LIBS += -stdlib=libc++
-QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+QMAKE_CXXFLAGS += -std=c++11
 
 DEFINES += LIBKEYFINDER_LIBRARY
 
@@ -74,6 +73,8 @@ SOURCES += \
 OTHER_FILES += README
 
 macx{
+  LIBS += -stdlib=libc++
+  QMAKE_CXXFLAGS += -stdlib=libc++
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
   QMAKE_MAC_SDK = macosx10.9
   CONFIG -= ppc ppc64 x86


### PR DESCRIPTION
This is in relation to [my comment here](https://github.com/ibsh/libKeyFinder/commit/816f37c9ec4f04bed9219748543e1e43d92e72a1#commitcomment-13176966) relating to building on Linux.

This moves the `-stdlib=libc++` to the OSX only section since *I believe* this is the only operating system that needs to be compiled with this flag is OSX. But I'm actually not completely positive.