### PR TITLE
Reconfigure .pro to install the .so and headers on unix/mac

### DIFF
--- a/LibKeyFinder.pro
+++ b/LibKeyFinder.pro
@@ -79,17 +79,25 @@ macx{
   QMAKE_MAC_SDK = macosx10.11
   CONFIG -= ppc ppc64 x86
   CONFIG += x86_64
-# installs
-  QMAKE_LFLAGS_SONAME  = -Wl,-install_name,/usr/local/lib/
+
+  # installation of headers and the shared object
+  target.path = /usr/local/lib
   headers.path = /usr/local/include/$$TARGET
-  headers.files = $$HEADERS
-  INSTALLS += headers
+  QMAKE_LFLAGS_SONAME = -Wl,-install_name,/usr/local/lib/
 }
 
-unix|macx{
+unix:!macx{
+  target.path = /usr/lib
+  headers.path = /usr/include/$$TARGET
+}
+
+unix{
   INCLUDEPATH += /usr/local/include
   LIBS += -L/usr/local/lib/
   LIBS += -lfftw3
+
+  INSTALLS += target headers
+  headers.files = $$HEADERS
 }
 
 win32{


### PR DESCRIPTION
In relation to [my comment here](https://github.com/ibsh/libKeyFinder/commit/571628e7eff6bab4e8434b28470f87c6ce369b8f#commitcomment-13177855)

This fixes the project file so that it correctly generates an install target on OSX and Unix for both the library file and the header files.

Platform | Library Path | Headers Path
---|---|---
**OSX** | `/usr/local/lib` | `/usr/local/include/keyfinder`
**Unix** | `/usr/lib` | `/usr/include/keyfinder`

I can't say that I'm 100% sure on what the `QMAKE_LFLAGS_SONAME` definition does, but I do know that using it on unix causes the linker to fail. I left it in for OSX, but I'm *pretty sure* OSX wasn't installing the library files either since it wasn't included in the `INSTALL`. Full disclosure though, I didn't fully test this on OSX since I'm having trouble getting qt working :frowning: 