### PR TITLE
Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Makefile
 .qmake.stash
 *.o
 *.dylib
+tests/tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: cpp
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  # Need to add this ppa for qt5 on Ubuntu 12.04. (Aside: stupid that adding a
+  # ppa takes --yes while installing takes --assume-yes...)
+  - sudo apt-add-repository --yes ppa:ubuntu-sdk-team/ppa
+
+  # Ubuntu 12.04 has an old gcc without C++11 support. Add this ppa so we can
+  # update it.
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+  
+  - sudo apt-get update --assume-yes
+
+  # Install newer gcc and g++.
+  - sudo apt-get install --assume-yes gcc-4.8 g++-4.8
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20
+  - sudo update-alternatives --config gcc
+  - sudo update-alternatives --config g++
+  
+  - sudo apt-get install --assume-yes build-essential
+  - sudo apt-get install --assume-yes qt5-default
+  - sudo apt-get install --assume-yes libboost-all-dev
+  - sudo apt-get install --assume-yes libfftw3-dev
+
+script: ./travis.sh

--- a/LibKeyFinder.pro
+++ b/LibKeyFinder.pro
@@ -79,17 +79,25 @@ macx{
   QMAKE_MAC_SDK = macosx10.9
   CONFIG -= ppc ppc64 x86
   CONFIG += x86_64
-# installs
-  QMAKE_LFLAGS_SONAME  = -Wl,-install_name,/usr/local/lib/
+
+  # installation of headers and the shared object
+  target.path = /usr/local/lib
   headers.path = /usr/local/include/$$TARGET
-  headers.files = $$HEADERS
-  INSTALLS += headers
+  QMAKE_LFLAGS_SONAME = -Wl,-install_name,/usr/local/lib/
+}
+
+unix{
+  target.path = /usr/lib
+  headers.path = /usr/include/$$TARGET
 }
 
 unix|macx{
   INCLUDEPATH += /usr/local/include
   LIBS += -L/usr/local/lib/
   LIBS += -lfftw3
+
+  INSTALLS += target headers
+  headers.files = $$HEADERS
 }
 
 win32{

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `libKeyFinder`
 
+[![Build Status](https://travis-ci.org/ibsh/libKeyFinder.png?branch=master)](https://travis-ci.org/ibsh/libKeyFinder)
+
 `libKeyFinder` can be used to estimate the musical key of digital recordings.
 
 It is the basis of the KeyFinder GUI app, which is available as a binary download for Mac OSX and Windows at www.ibrahimshaath.co.uk/keyfinder

--- a/README.md
+++ b/README.md
@@ -87,3 +87,23 @@ $ qmake
 $ make
 $ make install
 ```
+
+## Testing
+
+After having successfully installed the library following the above instructions, run the following commands to build and run the tests:
+
+```sh
+$ cd tests/
+$ qmake
+$ make
+$ ./tests
+```
+
+If all goes well, you should see something like this:
+
+```
+===============================================================================
+All tests passed (1705510 assertions in 65 test cases)
+```
+
+Note that there is a known intermittent failure in the `FftAdapterTest/ForwardAndBackward` test. Try running the tests a handful of times to determine whether you are hitting the intermittent or have introduced a new bug.

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -27,8 +27,7 @@ CONFIG -= app_bundle
 CONFIG -= qt
 
 CONFIG += c++11
-LIBS += -stdlib=libc++
-QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
+QMAKE_CXXFLAGS += -std=c++11
 
 LIBS += -lkeyfinder
 
@@ -56,6 +55,8 @@ SOURCES += \
     workspacetest.cpp
 
 macx{
+  LIBS += -stdlib=libc++
+  QMAKE_CXXFLAGS += -stdlib=libc++
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
   QMAKE_MAC_SDK = macosx10.9
   DEPENDPATH += /usr/local/lib

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Exit if any sub-command fails.
+set -e
+
+echo "Building on machine:"
+uname -a
+
+echo "CXX=$CXX"
+echo "$($CXX --version)"
+
+cd $(dirname $0)
+echo "Inside directory: $(pwd)"
+
+echo "Building and installing libKeyFinder."
+qmake
+make
+sudo make install
+
+echo "Building the tests."
+cd tests/
+echo "Inside directory: $(pwd)"
+
+qmake
+make
+
+# Warning: this is a bit hacky! We have a known intermittent failure. Try and
+# run the tests a reasonable amount of times such that if a commit didn't cause
+# the intermittent failure to become a permanent failure, or if a new test is
+# failing, then the tests should pass at least once.
+#
+# This hack ensures that we maintain a good signal to noise ratio for Travis CI
+# tests results for pull requests and new commits.
+
+echo "Running tests."
+
+./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || \
+    ./tests || {
+        echo "Tests consistently failing!"
+        exit 1
+    }


### PR DESCRIPTION
This builds on top of both #9 and #12.

Fixes #11, but requires you to go to travis-ci.org, login with github, and enable Travis CI for this repository. See http://docs.travis-ci.com/user/for-beginners/ for details on this process.

This PR has all the settings and test scripts needed to get the Travis CI test servers building and testing libKeyFinder, it just needs the appropriate settings flipped by you, the repo owner.

You can see an example build [here](https://travis-ci.org/fitzgen/libKeyFinder/builds/83057771) with full logs for gcc and clang when you click through.

Note that the intermittent seems to happen much more frequently and consistently on the Travis CI servers than they do locally (for me, at least) . So much so that even running the tests ten times didn't get a single passing state. I personally think the value of automatically running tests on checkin and for pull requests outweighs the value created by this flaky test now, and the failing assertion should be made to a TODO if gtest supports that (I haven't checked) or commented out if not. Thoughts?

I also had to move the `stdlib=libc++` to mac osx only for the tests as well, which I saw from earlier commits for the main `.pro` file.

Let me know if you have any questions about this, or if I can help in any other way! I think this is very helpful functionality for both contributors and you as a maintainer, so I am eager to do whatever you deem necessary to get this landed. I know you said you're relocating right now, so I understand if you want to hold off on reviewing this for a little bit. I hope it is going well!
