### PR TITLE
Lowpassfilter Leak

### DIFF
--- a/audiodata.cpp
+++ b/audiodata.cpp
@@ -179,16 +179,22 @@ namespace KeyFinder {
     }
     std::deque<double>::const_iterator readAt = samples.begin();
     std::deque<double>::iterator writeAt = samples.begin();
+
+    // Prevent std::advance out of iterator range problems
+    size_t numSamplesRemaining = samples.size();
+
     while (readAt < samples.end()) {
       double mean = 0.0;
-      if (shortcut) {
+      if (shortcut && numSamplesRemaining > factor) {
         mean = *readAt;
         std::advance(readAt, factor);
+        numSamplesRemaining -= factor;
       } else {
         for (unsigned int s = 0; s < factor; s++) {
           if (readAt < samples.end()) {
             mean += *readAt;
             std::advance(readAt, 1);
+            --numSamplesRemaining;
           }
           mean /= (double)factor;
         }

--- a/lowpassfilter.cpp
+++ b/lowpassfilter.cpp
@@ -49,6 +49,13 @@ namespace KeyFinder {
     priv = new LowPassFilterPrivate(order, frameRate, cornerFrequency, fftFrameSize);
   }
 
+  LowPassFilter::~LowPassFilter() {
+    if (priv != nullptr)
+    {
+      delete priv;
+    }
+  }
+
   void LowPassFilter::filter(AudioData& audio, Workspace& workspace, unsigned int shortcutFactor) const {
     priv->filter(audio, workspace, shortcutFactor);
   }

--- a/lowpassfilter.h
+++ b/lowpassfilter.h
@@ -33,6 +33,7 @@ namespace KeyFinder {
   class LowPassFilter {
   public:
     LowPassFilter(unsigned int order, unsigned int frameRate, double cornerFrequency, unsigned int fftFrameSize);
+    ~LowPassFilter();
     void filter(AudioData& audio, Workspace& workspace, unsigned int shortcutFactor = 1) const;
     void const * getCoefficients() const; // for unit testing only
   protected:


### PR DESCRIPTION
Found a memory leak in LowPassFilter.  I'm guessing it's meant to use the factory class but doesn't?  The constructor creates a new LowPassFilterPrivate for priv to point to, then priv is never destroyed.  Here's a trivial fix for now that just adds an explicit destructor to LowPassFilter and deletes it there