### PR TITLE
Initialize fft output memory

### DIFF
--- a/fftadapter.cpp
+++ b/fftadapter.cpp
@@ -40,6 +40,7 @@ namespace KeyFinder {
     frameSize = inFrameSize;
     priv->inputReal = (double*)fftw_malloc(sizeof(double) * frameSize);
     priv->outputComplex = (fftw_complex*)fftw_malloc(sizeof(fftw_complex) * frameSize);
+    memset(priv->outputComplex, 0, sizeof(fftw_complex) * frameSize);
     fftwPlanMutex.lock();
     priv->plan = fftw_plan_dft_r2c_1d(frameSize, priv->inputReal, priv->outputComplex, FFTW_ESTIMATE);
     fftwPlanMutex.unlock();


### PR DESCRIPTION
This fixes two out of four unittest failures.