### PR TITLE
Add alpine linux based travis test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Makefile
 *.o
 *.dylib
 tests/tests
+/ci/alpine/.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+services: docker
+language: generic
+
+cache:
+  directories:
+    - ci/alpine/.cache/
+
+before_cache:
+    - ./ci/alpine/clean-cache.sh
+
+script: ./ci/alpine.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # `libKeyFinder`
 
+[![Build Status](https://travis-ci.org/ibsh/libKeyFinder.svg?branch=master)](https://travis-ci.org/ibsh/libKeyFinder)
+
 `libKeyFinder` can be used to estimate the musical key of digital recordings.
 
 It is the basis of the KeyFinder GUI app, which is available as a binary download for Mac OSX and Windows at www.ibrahimshaath.co.uk/keyfinder

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+SCRIPT="$(pwd -P)/$0"
+BASE="${SCRIPT%/*}"
+echo Running alpine docker test at $BASE
+cd "$BASE"
+
+if [ -z "$CC" ]; then
+    echo Set CC=gcc since CC is undefined
+    export CC=gcc
+fi
+
+sudo docker run \
+    -e "HUID=$(id -u)" \
+    -e "CC=$CC" \
+    -v "$(pwd -P)/..":/outside \
+    alpine:edge \
+    /outside/ci/alpine/run.sh

--- a/ci/alpine/clean-cache.sh
+++ b/ci/alpine/clean-cache.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+rm -f ci/alpine/.cache/APKINDEX.*
+SIZE="$(du -s ci/alpine/.cache | sed 's/\t.*//')"
+if [ "$SIZE" -gt "280000" ]; then
+    echo Cleaning cache
+    rm -rf ci/alpine/.cache
+    mkdir -p ci/alpine/.cache
+    touch ci/alpine/.cache/.keep
+fi

--- a/ci/alpine/install.sh
+++ b/ci/alpine/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+cd /etc/apk
+ln -s /outside/ci/alpine/.cache cache
+cat > /etc/apk/repositories <<EOF
+http://dl-4.alpinelinux.org/alpine/edge/main
+http://dl-4.alpinelinux.org/alpine/edge/community
+http://dl-4.alpinelinux.org/alpine/edge/testing
+EOF
+apk update
+apk upgrade
+apk add \
+    alpine-sdk \
+    valgrind \
+    fftw-dev \
+    qt-dev

--- a/ci/alpine/memcheck.supp
+++ b/ci/alpine/memcheck.supp
@@ -1,0 +1,7 @@
+
+{
+   system-musl
+   Memcheck:Free
+   fun:free
+   obj:/lib/ld-musl-x86_64.so.1
+}

--- a/ci/alpine/run.sh
+++ b/ci/alpine/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/outside/ci/alpine/install.sh
+sudo -E -u \#$HUID /outside/ci/alpine/test.sh

--- a/ci/alpine/settings.patch
+++ b/ci/alpine/settings.patch
@@ -1,0 +1,13 @@
+diff -ur a/tests/tests.pro b/tests/tests.pro
+--- a/tests/tests.pro	2017-03-23 16:47:17.280248215 +0100
++++ b/tests/tests.pro	2017-03-23 16:48:28.386799769 +0100
+@@ -27,8 +27,8 @@ CONFIG -= app_bundle
+ CONFIG -= qt
+
+ CONFIG += c++11
+-LIBS += -stdlib=libc++
+-QMAKE_CXXFLAGS += -std=c++11 -stdlib=libc++
++LIBS += -L..
++QMAKE_CXXFLAGS += -std=c++11
+
+ LIBS += -lkeyfinder

--- a/ci/alpine/test.sh
+++ b/ci/alpine/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+cd /outside
+patch -p1 < ci/alpine/settings.patch
+qmake
+make
+cd tests
+ln -s /outside keyfinder
+qmake
+make
+LD_LIBRARY_PATH=".." ./tests
+LD_LIBRARY_PATH=".." valgrind \
+    --suppressions=/outside/ci/alpine/memcheck.supp \
+    --tool=memcheck ./tests


### PR DESCRIPTION
* Runs the tests
* Runs the tests with memcheck

Here is my test run:
https://travis-ci.org/ganwell/libKeyFinder/builds/214472336

I hope I did the changes to README.md correctly. I use the same setup for my library: https://github.com/concretecloud/chirp