### PR TITLE
Fix down-sampling shortcut

### DIFF
--- a/audiodata.cpp
+++ b/audiodata.cpp
@@ -185,9 +185,13 @@ namespace KeyFinder {
 
     while (readAt < samples.end()) {
       double mean = 0.0;
-      if (shortcut && numSamplesRemaining >= factor) {
+      if (shortcut) {
         mean = *readAt;
-        std::advance(readAt, factor);
+        if (numSamplesRemaining >= factor) {
+            std::advance(readAt, factor);
+        } else {
+            readAt = samples.end();
+        }
         numSamplesRemaining -= factor;
       } else {
         for (unsigned int s = 0; s < factor; s++) {


### PR DESCRIPTION
If the next loop takes us beyond the array bounds, we skip to the end.

@ibsh It would be nice if you could activate travis before accepting this PR, so we can check if everything works. BTW if you ever have a problem with this travis setup, just ping me.