### PR TITLE
Include cstring for memset definition

### DIFF
--- a/fftadapter.cpp
+++ b/fftadapter.cpp
@@ -23,6 +23,7 @@
 
 // Included here to allow substitution of a separate implementation .cpp
 #include <cmath>
+#include <cstring>
 #include <fftw3.h>
 
 namespace KeyFinder {


### PR DESCRIPTION
```
g++ -c -pipe -std=c++11 -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong -std=gnu++11 -Wall -W -fPIC -DLIBKEYFINDER_LIBRARY -I. -isystem /usr/local/include -I/usr/lib/qt/mkspecs/linux-g++ -o fftadapter.o fftadapter.cpp
fftadapter.cpp: In constructor ‘KeyFinder::FftAdapter::FftAdapter(unsigned int)’:
fftadapter.cpp:43:68: error: ‘memset’ was not declared in this scope
     memset(priv->outputComplex, 0, sizeof(fftw_complex) * frameSize);
                                                                    ^
make: *** [Makefile:353: fftadapter.o] Error 1
```

I think it may depend on the build environment, since this seems to build okay on my mac, but not on linux.