### PR TITLE
Remove QMAKE_MAC_SDK to fix build on newer macOS

### DIFF
--- a/LibKeyFinder.pro
+++ b/LibKeyFinder.pro
@@ -76,7 +76,6 @@ macx{
   LIBS += -stdlib=libc++
   QMAKE_CXXFLAGS += -stdlib=libc++
   QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
-  QMAKE_MAC_SDK = macosx10.12
   CONFIG -= ppc ppc64 x86
   CONFIG += x86_64
 


### PR DESCRIPTION
I had to make this change in my homebrew file here:

https://github.com/EvanPurkhiser/homebrew-personal/commit/8619868d6cc1bda48b516887e3347437c2480aed to get the [build working again](https://github.com/EvanPurkhiser/homebrew-personal/runs/478885668?check_suite_focus=true)

To get this building again on mac without the errror

```
Project ERROR: Could not resolve SDK SDKVersion for 'macosx10.12' using --show-sdk-version
```

I removed this as per the [comment in this forum post](https://forum.qt.io/topic/83447/made-the-mistake-of-updating-xcode)

> its not need after xcode7 to write sdk version.. ***
> cd /Applications/Xcode.app/Contents/Developer/Platforms
> open ./
>
> QMAKE_MAC_SDK is old..

Not sure if this will affect older macs, but it works for me.