### PR TITLE
CMake: Add Find module for FFTW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,9 @@ else()
   )
 endif()
 
-
-target_link_libraries(keyfinder fftw3)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+find_package(FFTW REQUIRED)
+target_link_libraries(keyfinder PUBLIC FFTW::FFTW)
 
 install(TARGETS keyfinder DESTINATION lib)
 install(FILES

--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -1,0 +1,70 @@
+#[=======================================================================[.rst:
+FindFFTW
+--------
+
+Finds the FFTW library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``FFTW::FFTW``
+  The FFTW library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``FFTW_FOUND``
+  True if the system has the FFTW library.
+``FFTW_INCLUDE_DIRS``
+  Include directories needed to use FFTW.
+``FFTW_LIBRARIES``
+  Libraries needed to link to FFTW.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``FFTW_INCLUDE_DIR``
+  The directory containing ``fftw3.h``.
+``FFTW_LIBRARY``
+  The path to the FFTW library.
+
+#]=======================================================================]
+
+find_path(FFTW_INCLUDE_DIR
+  NAMES fftw3.h
+  DOC "FFTW include directory")
+mark_as_advanced(FFTW_INCLUDE_DIR)
+
+find_library(FFTW_LIBRARY
+  NAMES fftw fftw3 fftw-3.3
+  DOC "FFTW library"
+)
+mark_as_advanced(FFTW_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  FFTW
+  DEFAULT_MSG
+  FFTW_LIBRARY
+  FFTW_INCLUDE_DIR
+)
+
+if(FFTW_FOUND)
+  set(FFTW_LIBRARIES "${FFTW_LIBRARY}")
+  set(FFTW_INCLUDE_DIRS "${FFTW_INCLUDE_DIR}")
+
+  if(NOT TARGET FFTW::FFTW)
+    add_library(FFTW::FFTW UNKNOWN IMPORTED)
+    set_target_properties(FFTW::FFTW
+      PROPERTIES
+        IMPORTED_LOCATION "${FFTW_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${FFTW_INCLUDE_DIR}"
+    )
+  endif()
+endif()


### PR DESCRIPTION
Instead of hardcoding the library name and assuming that `fftw3.h` is already in the include path, CMake should use [`find_package(FFTW)`](https://cmake.org/cmake/help/latest/command/find_package.html).